### PR TITLE
NO-TASK - Prevent loosing of already configured settings.

### DIFF
--- a/ting_extended_search.module
+++ b/ting_extended_search.module
@@ -325,3 +325,12 @@ function theme_ting_ext_search_display_table(&$variables) {
 
   return $output;
 }
+
+/**
+ * Implements hook_features_pre_restore().
+ */
+function ting_extended_search_features_pre_restore($op, $items) {
+  if (isset($items['ting_extended_search']) && in_array('variable', $items['ting_extended_search'])) {
+    features_feature_lock('ting_extended_search', 'variable');
+  }
+}


### PR DESCRIPTION
This will lock the 'Strongarm' component of Ting Extended Search feature in order to prevent the loosing of already configured settings in the backend.